### PR TITLE
Fix player input integer

### DIFF
--- a/TICTAC.py
+++ b/TICTAC.py
@@ -63,17 +63,18 @@ def handle_turn(player):
   while not valid:
 
     # Make sure the input is valid
-    while position not in ["1", "2", "3", "4", "5", "6", "7", "8", "9"]:
+    while position not in range(1, 10):
       position = input("Choose a position from 1-9: ")
  
     # Get correct index in our board list
-    position = int(position) - 1
+    position -= 1
 
     # Then also make sure the spot is available on the board
     if board[position] == "-":
       valid = True
     else:
       print("You can't go there. Go again.")
+      position = None
 
   # Put the game piece on the board
   board[position] = player


### PR DESCRIPTION
Player can now enter en INTEGER (from 1 to 9) instead of a non-intuitive STRING with appropriate quotes ("1", "2", ...)

### Before this patch

```
$ python TICTAC.py


- | - | -     1 | 2 | 3
- | - | -     4 | 5 | 6
- | - | -     7 | 8 | 9


X's turn.
Choose a position from 1-9: 1
Choose a position from 1-9: "1"


X | - | -     1 | 2 | 3
- | - | -     4 | 5 | 6
- | - | -     7 | 8 | 9


O's turn.
Choose a position from 1-9: "3"


X | - | O     1 | 2 | 3
- | - | -     4 | 5 | 6
- | - | -     7 | 8 | 9


X's turn.
```

### After this patch

```
$ python TICTAC.py


- | - | -     1 | 2 | 3
- | - | -     4 | 5 | 6
- | - | -     7 | 8 | 9


X's turn.
Choose a position from 1-9: 1


X | - | -     1 | 2 | 3
- | - | -     4 | 5 | 6
- | - | -     7 | 8 | 9


O's turn.
Choose a position from 1-9: 3


X | - | O     1 | 2 | 3
- | - | -     4 | 5 | 6
- | - | -     7 | 8 | 9


X's turn.
```

Far better, isn't it? :)